### PR TITLE
Fixed broken Get Started link on homepage

### DIFF
--- a/components/GetStarted.tsx
+++ b/components/GetStarted.tsx
@@ -6,7 +6,7 @@ export default function GetStarted({ centered }: { centered?: boolean }) {
   return (
     <>
       <p className={centered !== false ? "centered" : ""}>
-        <Button href="//app.getoutline.com/create">
+        <Button href="https://app.getoutline.com/create">
           Get Started for Free &rarr;
         </Button>
         <small className="note">30 day trial, no credit card required</small>


### PR DESCRIPTION
The **live** website returns `https://www.getoutline.com/app.getoutline.com/create` (a 404) when clicking the `Get Started for Free` button. This fixes that link:

<img width="955" alt="Screen Shot 2021-08-17 at 4 36 32 AM" src="https://user-images.githubusercontent.com/22891173/129692849-ac8ed117-a6ca-4d0b-9a62-e4f860365166.png">


