### PR TITLE
Fix "open source" usage

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -319,7 +319,7 @@ export default function Home() {
                   title={
                     <>
                       <GithubLogo size={24} />
-                      &nbsp;Open source
+                      &nbsp;Ajar source
                     </>
                   }
                   description={


### PR DESCRIPTION
Hi, I noticed on getoutline.com that the term "Open source" was used, even though the BSL license is not an open-source license.

I did see that by now, some old versions are open-source through the Change Date, but I think it would still be more honest to use a different term. I saw [you've removed the term "Open Source" before](https://github.com/outline/website/commit/d6eee8ebec2e39d533f2c4afa0adbe0c5011d496), so maybe this one fell through the cracks.

Obviously feel free to use different terminology than "ajar", just wanted to raise awareness :smile: 