### PR TITLE
Add changelog posts for image resize handles and Cloudflare R2 support

### DIFF
--- a/posts/cloudflare-r2-support.md
+++ b/posts/cloudflare-r2-support.md
@@ -1,0 +1,9 @@
+---
+title: Cloudflare R2 storage support
+date: 2026-06-25T00:00:00Z
+slug: cloudflare-r2-support
+---
+
+Self-hosted Outline instances can now store uploads on Cloudflare R2 and other S3-compatible providers that don't support presigned POST uploads. Set `AWS_S3_UPLOAD_METHOD=put` in your environment to switch to presigned PUT requests — the existing `post` behavior remains the default, so nothing changes for current deployments.
+
+This closes a long-standing gap for teams running Outline on R2's cheap, egress-free storage, and paves the way for supporting other S3-compatible backends with similar constraints.

--- a/posts/image-resize-handles.md
+++ b/posts/image-resize-handles.md
@@ -1,0 +1,9 @@
+---
+title: Image resize handles
+date: 2026-06-25T00:00:00Z
+slug: image-resize-handles
+---
+
+You can now resize images directly from their corners, not just the sides. Select an image and drag any of the four corner handles to scale it up or down — the aspect ratio locks automatically so images never end up stretched or squashed. Double-click a corner handle to reset it back to its natural size.
+
+It's a small change, but it brings image editing in Outline in line with the drag-to-resize interactions you already know from tools like Google Docs and Notion.


### PR DESCRIPTION
## Summary

Reviewed PRs merged in [outline/outline](https://github.com/outline/outline) over the last week (2026-06-24 to 2026-07-01) and picked out two standout, user-facing features worth a changelog post:

- **Image resize handles** — the editor now supports dragging from any of an image's four corners to resize it, with the aspect ratio locked automatically (and a double-click to reset to natural size). Based on [outline/outline#12690](https://github.com/outline/outline/pull/12690).
- **Cloudflare R2 storage support** — self-hosted instances can now use presigned PUT uploads (`AWS_S3_UPLOAD_METHOD=put`) for S3-compatible storage providers, like Cloudflare R2, that don't implement presigned POST. Based on [outline/outline#12748](https://github.com/outline/outline/pull/12748).

A third candidate, spec-compliant OIDC logout ([outline/outline#12804](https://github.com/outline/outline/pull/12804)), was considered but left out — it's more of a security/spec-compliance fix than a headline feature, and has no user-visible UI surface to highlight.

## Test plan

- [x] Verified YAML frontmatter parses correctly and `slug` matches each filename
- [x] Matched tone/structure of recent posts (`toggle-headings.md`, `desktop-improvements.md`, `gitlab.md`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxPJBRJ6NYGyB8Y9fzQRFx)_