### PR TITLE
Add changelog post for table row alignment

### DIFF
--- a/posts/table-row-alignment.md
+++ b/posts/table-row-alignment.md
@@ -1,0 +1,9 @@
+---
+title: Table row alignment
+date: 2026-07-08T00:00:00Z
+slug: table-row-alignment
+---
+
+You can now set text alignment for an entire table row in one step. Select a row using the row handle, choose **Align** from the row toolbar, then pick left, center, or right — the alignment is applied to every cell in that row at once.
+
+This sits alongside the existing per-column alignment, giving you finer control over how data is laid out inside tables.


### PR DESCRIPTION
## Summary
- Reviewed pull requests merged in `outline/outline` over the last week (Jul 1–8, 2026)
- Added a new changelog post for [outline/outline#12898](https://github.com/outline/outline/pull/12898), which adds row-level text alignment to tables (an **Align** control in the table row toolbar that applies left/center/right alignment to every cell in the selected row)
- Other merged PRs from the week were mostly bug fixes, dependency bumps, and internal chores that didn't warrant a standalone changelog entry

## New file
- `posts/table-row-alignment.md`

Frontmatter and tone follow the style of recent posts (e.g. `toggle-headings.md`, `date-mentions.md`, `task-list-improvements.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pnos4aYHDMyQJuvWw136zZ)_