### PR TITLE
Add changelog post for split view

### DIFF
--- a/posts/split-view.md
+++ b/posts/split-view.md
@@ -1,0 +1,13 @@
+---
+title: Split view
+date: 2026-07-22T00:00:00Z
+slug: split-view
+---
+
+You can now open two documents side by side with the new split view, making it easy to reference one document while working in another.
+
+- **Open a second pane** – choose "Open in split view" from a document or collection's menu, or from the command bar
+- **Quick shortcuts** – modifier-click any link in the sidebar or editor (in the desktop app), or press `Cmd+Enter`/`Ctrl+Enter` from the command menu, to open it in the split pane instead of navigating away
+- **Resizable panes** – drag the divider between panes to adjust their widths, or double-click it to reset to an even split
+
+Each pane keeps its own navigation history, so links you click inside a pane open within that pane rather than replacing what you're viewing elsewhere. Comments and history panels also work independently per pane.


### PR DESCRIPTION
## Summary
- Adds a new changelog post highlighting **split view**, a standout feature merged into `outline/outline` this past week (outline/outline#13044, outline/outline#13073), which lets users open two documents side by side and navigate each pane independently.
- Frontmatter (`title`, `date`, `slug`) follows the convention of other recent posts, and the filename matches the `slug` exactly.

## Test plan
- [x] Verified frontmatter format matches recent posts (`posts/desktop-improvements.md`, `posts/mcp-improvements.md`, etc.)
- [x] Confirmed no existing post uses the `split-view` slug/filename
- [ ] Visually verify rendering on the deployed preview


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLqSk8haWQ2qwnmHH2xfsP)_