### PR TITLE
Add changelog posts for live document stats, split view links, and settings table columns

### DIFF
--- a/posts/document-stats.md
+++ b/posts/document-stats.md
@@ -1,0 +1,9 @@
+---
+title: Live document stats
+date: 2026-08-08T00:00:00Z
+slug: document-stats
+---
+
+A live stats bar now sits in the corner of the editor, showing word count, character count, paragraph count, and estimated reading time as you write.
+
+Select some text and the bar switches to show the word and character count for just that selection, then reverts to the full document once you click away. It fades out while you're idle so it stays out of the way, and can be turned off entirely from **Settings** if you'd rather not see it — look for **Show editing stats**, also available from the document and command menus, or toggle it with `Cmd/Ctrl+Shift+G`.

--- a/posts/modifier-click-split-view.md
+++ b/posts/modifier-click-split-view.md
@@ -1,0 +1,9 @@
+---
+title: Modifier-click to open in split view
+date: 2026-08-11T00:00:00Z
+slug: modifier-click-split-view
+---
+
+Opening a link in the secondary split-view pane now works consistently everywhere, not just in a handful of places.
+
+Hold `Cmd/Ctrl` and click any internal link in the desktop app, or `Cmd/Ctrl+Shift` and click in the browser (so a plain `Cmd/Ctrl+click` still opens a new tab as expected), and it opens beside your current document instead of replacing it — handy for following a reference or backlink without losing your place.

--- a/posts/settings-table-columns.md
+++ b/posts/settings-table-columns.md
@@ -1,0 +1,9 @@
+---
+title: Customizable settings table columns
+date: 2026-08-07T00:00:00Z
+slug: settings-table-columns
+---
+
+The tables across workspace settings — users, groups, templates, shares, emojis, API keys, and webhooks — now let you choose which columns are visible, so you can trim them down to just what you need.
+
+Right-click a header row, or use the new button at its end, to toggle individual columns on or off, the same way you would in Finder. Your choices are remembered per table, and admins get two new columns to work with on the users table: **Invited by** and **Joined**.


### PR DESCRIPTION
## Summary

Three standout features merged to `outline/outline` in the last week (Aug 5–12), each written up as a changelog post:

- **Live document stats** ([outline/outline#13318](https://github.com/outline/outline/pull/13318)) – word, character, and paragraph counts plus reading time in a live bar in the editor corner, with a selection-aware mode and a toggle in Settings.
- **Modifier-click to open in split view** ([outline/outline#13368](https://github.com/outline/outline/pull/13368)) – Cmd/Ctrl-click (desktop) or Cmd/Ctrl+Shift-click (browser) now opens any internal link in the secondary split-view pane, consistently across the app.
- **Customizable settings table columns** ([outline/outline#13326](https://github.com/outline/outline/pull/13326)) – right-click a header row (or use the new button) to toggle columns on/off across the users, groups, templates, shares, emojis, API keys, and webhooks tables; choices persist per table.

PDF import (outline/outline#13302) was already covered in last week's `new-import-formats` post, so it's not repeated here.

## Test plan

- [x] Verified frontmatter (`title`, `date`, `slug`) matches the format used by recent posts
- [x] Confirmed each file name matches its `slug` field exactly
- [ ] Visual review / images can be added in a follow-up commit, matching the pattern of other recent posts


---
_Generated by [Claude Code](https://claude.ai/code/session_01LpfmUt9fBK1EDTivmAjBAt)_