### PR TITLE
Add homepage social proof stats

### DIFF
--- a/components/SocialProof.tsx
+++ b/components/SocialProof.tsx
@@ -11,6 +11,11 @@ export default function SocialProof() {
             <span className="label">companies</span>
           </div>
           <div className="divider" aria-hidden="true" />
+          <div className="stat">
+            <span className="value">10 years</span>
+            <span className="label">open source</span>
+          </div>
+          <div className="divider" aria-hidden="true" />
           <a
             className="stat link"
             href="https://github.com/outline/outline"
@@ -27,8 +32,7 @@ export default function SocialProof() {
           width: 100%;
           display: flex;
           justify-content: center;
-          padding: ${spacing.large} ${spacing.medium}
-            ${spacing.xlarge};
+          padding: ${spacing.large} ${spacing.medium} ${spacing.xlarge};
         }
 
         .stats {

--- a/components/SocialProof.tsx
+++ b/components/SocialProof.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import { colors, spacing } from "theme";
+
+export default function SocialProof() {
+  return (
+    <>
+      <section className="social-proof" aria-label="Social proof">
+        <div className="stats">
+          <div className="stat">
+            <span className="value">10,000+</span>
+            <span className="label">companies</span>
+          </div>
+          <div className="divider" aria-hidden="true" />
+          <a
+            className="stat link"
+            href="https://github.com/outline/outline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="value">40k</span>
+            <span className="label">GitHub stars</span>
+          </a>
+        </div>
+      </section>
+      <style jsx>{`
+        .social-proof {
+          width: 100%;
+          display: flex;
+          justify-content: center;
+          padding: ${spacing.large} ${spacing.medium}
+            ${spacing.xlarge};
+        }
+
+        .stats {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: ${spacing.xlarge};
+          flex-wrap: wrap;
+        }
+
+        .stat {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+          text-decoration: none;
+          color: inherit;
+          min-width: 140px;
+        }
+
+        .link:hover .value,
+        .link:focus .value {
+          color: ${colors.primary};
+        }
+
+        .link:hover .label,
+        .link:focus .label {
+          color: ${colors.primary};
+        }
+
+        .value {
+          font-size: 2.4rem;
+          font-weight: 600;
+          line-height: 1.1;
+          letter-spacing: -0.02em;
+          color: ${colors.almostBlack};
+          transition: color 0.15s ease;
+        }
+
+        .label {
+          margin-top: ${spacing.small};
+          font-size: 1rem;
+          color: ${colors.textSecondary};
+          transition: color 0.15s ease;
+        }
+
+        .divider {
+          width: 1px;
+          height: 48px;
+          background: ${colors.greyMid};
+        }
+
+        @media (max-width: 48em) {
+          .social-proof {
+            padding: ${spacing.medium} ${spacing.medium} ${spacing.large};
+          }
+
+          .stats {
+            gap: ${spacing.large};
+          }
+
+          .divider {
+            display: none;
+          }
+
+          .value {
+            font-size: 2rem;
+          }
+
+          .stat {
+            min-width: 120px;
+          }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/components/SocialProof.tsx
+++ b/components/SocialProof.tsx
@@ -7,8 +7,8 @@ export default function SocialProof() {
       <section className="social-proof" aria-label="Social proof">
         <div className="stats">
           <div className="stat">
-            <span className="value">10,000+</span>
-            <span className="label">companies</span>
+            <span className="value">2,000+</span>
+            <span className="label">customers</span>
           </div>
           <div className="divider" aria-hidden="true" />
           <div className="stat">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,6 +12,7 @@ import {
 import Card from "components/Card";
 import Screenshot from "components/Screenshot";
 import GetStarted from "components/GetStarted";
+import SocialProof from "components/SocialProof";
 import Layout from "components/Layout";
 import GithubLogo from "components/GithubLogo";
 import { spacing, colors, typography } from "theme";
@@ -40,6 +41,8 @@ export default function Home() {
 
           <Screenshot />
         </div>
+
+        <SocialProof />
 
         <h1 className="subtitle">Why you’ll love using Outline</h1>
         <p className="description">


### PR DESCRIPTION
## Summary
- Adds a social-proof strip on the homepage with high-level traction metrics: **10,000+ companies** and **40k GitHub stars**
- Stars link to https://github.com/outline/outline
- No named customers or logos (many teams self-host and stay private)

The section sits directly under the hero screenshot so visitors get a trust signal before the feature grid.

## Test plan
- [ ] Load the homepage and confirm the stats appear below the hero
- [ ] Confirm “40k GitHub stars” links to https://github.com/outline/outline
- [ ] Check mobile: stats stack cleanly, divider hides
- [ ] Check that hover/focus on the stars link uses the existing primary color