### PR TITLE
Add changelog posts for sticky table columns and trash filters

### DIFF
--- a/posts/sticky-table-columns.md
+++ b/posts/sticky-table-columns.md
@@ -1,0 +1,9 @@
+---
+title: Sticky table columns
+date: 2026-08-15T00:00:00Z
+slug: sticky-table-columns
+---
+
+Wide tables in the editor can now keep their first column in place while you scroll horizontally, the same way header rows already stick to the top of the screen.
+
+This makes it much easier to keep track of what a row represents when a table has a lot of columns — the label stays put as you scroll through the data. It kicks in automatically whenever the first column is set as a header column, and works alongside sticky header rows too.

--- a/posts/trash-filters.md
+++ b/posts/trash-filters.md
@@ -1,0 +1,9 @@
+---
+title: Trash filters
+date: 2026-08-18T00:00:00Z
+slug: trash-filters
+---
+
+The trash now defaults to showing only the items you deleted, instead of everything removed across the workspace, making it much faster to find and restore something you just trashed.
+
+Need to see more? Use the new **user** and **date** filters to widen the view — browse deletions by a teammate, or go further back in time. They work the same way as the filters in search, so the experience should already feel familiar.


### PR DESCRIPTION
## Summary

Reviewed pull requests merged in the outline/outline repo over the last week and picked out two standout, user-facing features to write up as changelog posts:

- **`posts/sticky-table-columns.md`** — covers [outline/outline#13444](https://github.com/outline/outline/pull/13444), which keeps a table's first column pinned in place while scrolling horizontally through wide tables, mirroring the existing sticky header row behavior.
- **`posts/trash-filters.md`** — covers [outline/outline#13474](https://github.com/outline/outline/pull/13474), which defaults the trash view to items the current user deleted, with new user and date filters (matching the shape of the search filters) to widen it again.

Both posts follow the existing frontmatter conventions (`title`, `date`, `slug`) and match the tone/length of other recent short-form changelog entries (e.g. `mcp-improvements.md`, `multi-select.md`). File names match their `slug` frontmatter values.

## Test plan

- [x] Verified frontmatter matches the format of recent posts (title/date/slug)
- [x] Verified the markdown filename matches the `slug` field exactly for both posts
- [ ] Visual check that the posts render correctly on the site (not run in this session)


---
_Generated by [Claude Code](https://claude.ai/code/session_018ySKSV2p46ZYDsRXu517Sg)_