### PR TITLE
Add changelog posts for heading numbering and sidebar section reordering

### DIFF
--- a/posts/heading-numbering.md
+++ b/posts/heading-numbering.md
@@ -1,0 +1,11 @@
+---
+title: Heading numbering
+date: 2026-08-22T00:00:00Z
+slug: heading-numbering
+---
+
+Long, structured documents — specs, policies, reports — are often easier to navigate and reference when headings are numbered. You can now turn this on for any document from the display options in the document menu.
+
+Choose from three numbering styles: decimal (1.1.1), alphanumeric (1.a.i), or Harvard (I.A.1). Outline numbers every heading automatically and keeps the table of contents in sync as you add, remove, or reorder sections. Click a number to jump your cursor straight to that heading, and rest easy knowing headings inside tables are left out of the count.
+
+Copying text keeps the numbers intact, so referencing a section elsewhere is accurate, while pasting back into the editor strips them out to avoid duplicates.

--- a/posts/sidebar-sections.md
+++ b/posts/sidebar-sections.md
@@ -1,0 +1,9 @@
+---
+title: Reorder sidebar sections
+date: 2026-08-22T00:00:00Z
+slug: sidebar-sections
+---
+
+The sidebar is organized into sections — Starred, Shared with me, and Collections — and now you can drag them into whatever order works best for you, not just the items within them.
+
+Grab a section header and drop it where you'd like; your preferred order is saved to your account and stays consistent across every device you sign in from. Empty sections tuck themselves out of the way automatically, so your sidebar only ever shows what's relevant to you.


### PR DESCRIPTION
## Summary
- Reviewed PRs merged in `outline/outline` over the past week (Aug 19–24) and picked out the two that stood out as customer-facing features worth a changelog post
- Add `posts/heading-numbering.md` covering the new per-document heading numbering display option (decimal, alphanumeric, and Harvard styles), shipped in [outline/outline#13522](https://github.com/outline/outline/pull/13522)
- Add `posts/sidebar-sections.md` covering the new ability to drag-reorder sidebar sections (Starred, Shared with me, Collections), shipped in [outline/outline#13505](https://github.com/outline/outline/pull/13505)

Both posts follow the frontmatter and tone of other recent single-feature posts (e.g. `multi-select.md`, `profile-cards.md`, `mcp-improvements.md`), with the markdown file name matching the `slug` field exactly.

## Test plan
- [x] Frontmatter fields (`title`, `date`, `slug`) match the shape expected by `lib/posts.ts`
- [x] File names match `slug` exactly
- [x] Manually compared tone/length against recent posts in `posts/`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TryEzUBdWyss1BtvipkSPj)_