### PR TITLE
Add changelog post for HEIC/HEIF avatar upload support

### DIFF
--- a/posts/heic-avatar-uploads.md
+++ b/posts/heic-avatar-uploads.md
@@ -1,0 +1,9 @@
+---
+title: HEIC and HEIF avatar uploads
+date: 2026-08-28T00:00:00Z
+slug: heic-avatar-uploads
+---
+
+You can now upload HEIC and HEIF photos — the formats used natively by iPhones and Macs — directly as your avatar, no need to convert them yourself first. Outline converts the image to JPEG in your browser before the cropper opens, so uploading is just as fast as with any other format.
+
+If your browser doesn't support decoding HEIC/HEIF natively, you'll be asked to upload a JPEG or PNG instead.


### PR DESCRIPTION
## Summary
- Reviewed pull requests merged in the outline/outline repo over the past week (Aug 26 – Sep 2, 2026)
- Added a new changelog post highlighting [outline/outline#13577](https://github.com/outline/outline/pull/13577), which adds support for uploading HEIC/HEIF photos (the native format on iPhones and Macs) as an avatar, with in-browser conversion to JPEG before the cropper opens
- Other merged PRs in the window were bug fixes, chores, or dependency bumps and didn't warrant a standalone changelog entry

## Test plan
- [x] Verified frontmatter (`title`, `date`, `slug`) matches the style of recent posts
- [x] Verified the markdown filename matches the `slug` field exactly
- [x] Confirmed no manifest/index file needs updating — posts are discovered directly from the `posts/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7eWUDaUB8aGw8g38753jF

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7eWUDaUB8aGw8g38753jF)_