### PR TITLE
Add changelog posts for WebMCP support and OKF export

### DIFF
--- a/posts/okf-export.md
+++ b/posts/okf-export.md
@@ -4,6 +4,6 @@ date: 2026-09-04T00:00:00Z
 slug: okf-export
 ---
 
-Collections and workspaces can now be exported in the Open Knowledge Format (OKF), an open, portable bundle of markdown files designed to keep your content and its metadata readable outside of Outline.
+Collections and workspaces can now be exported in the [Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) (OKF), an open, portable bundle of markdown files designed to keep your content and its metadata readable outside of Outline.
 
 Each document is exported as markdown with YAML frontmatter describing its title, type, description, and when it was generated, and every bundle includes a root `index.md` that declares the OKF version and lists its top-level entries. It's available anywhere you can already export to markdown — just pick "OKF" as the format from the export dialog.

--- a/posts/okf-export.md
+++ b/posts/okf-export.md
@@ -1,0 +1,9 @@
+---
+title: Open Knowledge Format export
+date: 2026-09-04T00:00:00Z
+slug: okf-export
+---
+
+Collections and workspaces can now be exported in the Open Knowledge Format (OKF), an open, portable bundle of markdown files designed to keep your content and its metadata readable outside of Outline.
+
+Each document is exported as markdown with YAML frontmatter describing its title, type, description, and when it was generated, and every bundle includes a root `index.md` that declares the OKF version and lists its top-level entries. It's available anywhere you can already export to markdown — just pick "OKF" as the format from the export dialog.

--- a/posts/webmcp-support.md
+++ b/posts/webmcp-support.md
@@ -4,11 +4,8 @@ date: 2026-09-09T00:00:00Z
 slug: webmcp-support
 ---
 
-Outline now has experimental support for WebMCP, a browser standard that lets in-page AI agents discover and call structured tools directly through `document.modelContext`. This means agents in Chrome and ChatGPT can programmatically control Outline through the browser itself, no separate server connection required.
+Outline now has support for WebMCP, a browser standard that lets in-page AI agents discover and call structured tools directly through `document.modelContext`. This means agents in Chrome and ChatGPT can programmatically control Outline through the browser itself, no separate server connection required.
 
 - **Action mirroring** – existing command bar actions are automatically registered as WebMCP tools, complete with the same visibility rules and context you already get in the UI
-- **New agent-only tools** – `get_current_context` and `search_workspace` give agents a quick way to orient themselves in your workspace
 - **Safety controls** – destructive actions like deletes are excluded from what agents can call
 - **Team preference gating** – WebMCP sits behind your workspace's existing MCP settings, so it's off unless MCP is enabled for your team
-
-This requires Chrome 146+ with the WebMCP flag enabled, and support will expand as the standard matures.

--- a/posts/webmcp-support.md
+++ b/posts/webmcp-support.md
@@ -1,0 +1,14 @@
+---
+title: WebMCP support
+date: 2026-09-09T00:00:00Z
+slug: webmcp-support
+---
+
+Outline now has experimental support for WebMCP, a browser standard that lets in-page AI agents discover and call structured tools directly through `document.modelContext`. This means agents in Chrome and ChatGPT can programmatically control Outline through the browser itself, no separate server connection required.
+
+- **Action mirroring** – existing command bar actions are automatically registered as WebMCP tools, complete with the same visibility rules and context you already get in the UI
+- **New agent-only tools** – `get_current_context` and `search_workspace` give agents a quick way to orient themselves in your workspace
+- **Safety controls** – destructive actions like deletes are excluded from what agents can call
+- **Team preference gating** – WebMCP sits behind your workspace's existing MCP settings, so it's off unless MCP is enabled for your team
+
+This requires Chrome 146+ with the WebMCP flag enabled, and support will expand as the standard matures.


### PR DESCRIPTION
## Summary

Reviewed pull requests merged on `outline/outline` in the last week (2026-09-02 to 2026-09-09) and picked out two standout features worth announcing:

- **WebMCP support** (outline/outline#13576) – experimental support for the WebMCP browser standard, letting in-page AI agents (e.g. Chrome, ChatGPT) discover and call structured tools via `document.modelContext`.
- **Open Knowledge Format export** (outline/outline#13644) – a new export option that bundles collections/workspaces as portable markdown with YAML frontmatter metadata.

Both new posts follow the frontmatter (`title`, `date`, `slug`) and tone of other recent posts in `posts/`, and each markdown filename matches its `slug` field.

## Test plan

- [x] Verified frontmatter format matches recent posts (e.g. `mcp-improvements.md`, `multi-select.md`)
- [x] Confirmed filenames match `slug` frontmatter exactly
- [x] Cross-checked feature details against the source PRs on outline/outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQnSHeQeh7Aa1YE9qseuqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQnSHeQeh7Aa1YE9qseuqk)_